### PR TITLE
Fix warped 3ds rendering

### DIFF
--- a/amius_adventure/src/camera.cpp
+++ b/amius_adventure/src/camera.cpp
@@ -9,8 +9,8 @@ Camera::Camera(glm::vec3 position, glm::vec3 rotation, float zNear, float zFar, 
 glm::mat4x4* Camera::getTransform() {
     if (this->isDirty) {
         this->transform = glm::mat4x4(1.0f);
-        this->transform = this->transform * glm::mat4_cast(glm::quat(this->rotation));
         this->transform = glm::translate(this->transform, this->position);
+        this->transform = this->transform * glm::mat4_cast(glm::quat(this->rotation));
         this->isDirty = false;
     }
     return &this->transform;

--- a/amius_adventure/src/scene.cpp
+++ b/amius_adventure/src/scene.cpp
@@ -89,9 +89,9 @@ void Object::setScale(glm::vec3 scale) {
 glm::mat4x4* Object::getTransform() {
     if (this->isDirty) {
         this->transform = glm::mat4x4(1.0f);
-        this->transform = glm::scale(this->transform, this->scale);
-        this->transform = this->transform * glm::mat4_cast(glm::quat(this->rotation));
         this->transform = glm::translate(this->transform, this->position);
+        this->transform = this->transform * glm::mat4_cast(glm::quat(this->rotation));
+        this->transform = glm::scale(this->transform, this->scale);
         this->isDirty = false;
     }
     return &this->transform;

--- a/n3ds_platform/src/render.cpp
+++ b/n3ds_platform/src/render.cpp
@@ -232,7 +232,7 @@ bool drawCube(std::string texture, C3D_Mtx modelView) {
     }
 
     C3D_Mtx adjustedView;
-    Mtx_Multiply(&adjustedView, &cameraView, &modelView);
+    Mtx_Multiply(&adjustedView, &modelView, &cameraView);
 
     C3D_FVUnifMtx4x4(GPU_VERTEX_SHADER, uLoc_modelView, &adjustedView);
 
@@ -259,7 +259,7 @@ bool drawModel(std::string model, std::string texture, C3D_Mtx modelView) {
     }
 
     C3D_Mtx adjustedView;
-    Mtx_Multiply(&adjustedView, &cameraView, &modelView);
+    Mtx_Multiply(&adjustedView, &modelView, &cameraView);
 
     C3D_FVUnifMtx4x4(GPU_VERTEX_SHADER, uLoc_modelView, &adjustedView);
 


### PR DESCRIPTION
Previous versions used `C3D_Mtx` which is row-major. Since `glm::mat4` is column-major all existing matrix multiplications were happening in reverse order. This threw off the world space and view space calculations.

This PR reverses the matrix multiplication order in the 3ds renderer to correct this.